### PR TITLE
Add support for Ubuntu 24/python 3.12

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -140,7 +140,7 @@
 - name: os_horizon
   scm: git
   src: https://github.com/elastx/openstack-ansible-os_horizon
-  version: 6d1c06237971954deef53a357735560782f59e47
+  version: 565177eca63c89f0991fea070684a552c353a391
   trackbranch: elastx/yoga
   shallow_since: '2022-08-11'
 - name: os_ironic
@@ -182,7 +182,7 @@
 - name: os_neutron
   scm: git
   src: https://github.com/elastx/openstack-ansible-os_neutron
-  version: e562bb1c2fe11a6fc290fa2931aa8396828facd7
+  version: 2bc8ff6769efa5bce47700d0f9cae03aa2de1529
   trackbranch: elastx/yoga
   shallow_since: '2023-10-12'
 - name: os_nova

--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -55,9 +55,9 @@
   shallow_since: '2024-02-07'
 - name: openstack_hosts
   scm: git
-  src: https://opendev.org/openstack/openstack-ansible-openstack_hosts
-  version: d3186b2c14784cfeaa6ca9051cf55b4c9e31e68b
-  trackbranch: unmaintained/yoga
+  src: https://github.com/elastx/openstack-ansible-openstack_hosts
+  version: 1461516179e6fd36aca28bfab7979c36a4eea4fa
+  trackbranch: elastx/yoga
   shallow_since: '2024-07-07'
 - name: os_keystone
   scm: git

--- a/global-requirement-pins.txt
+++ b/global-requirement-pins.txt
@@ -6,7 +6,10 @@
 # Use this file with caution!
 #
 
-pip==21.3.1
-setuptools==67.8.0;python_version>'3.8'
-wheel==0.37.0
+pip==21.3.1;python_version<'3.12'
+pip==24.0;python_version>='3.12'
+setuptools==67.8.0;python_version>'3.8' and python_version<'3.12'
+setuptools==69.2.0;python_version>='3.12'
+wheel==0.37.0;python_version<'3.12'
+wheel==0.43.0;python_version>='3.12'
 uWSGI==2.0.20

--- a/playbooks/openstack-hosts-setup.yml
+++ b/playbooks/openstack-hosts-setup.yml
@@ -56,6 +56,7 @@
           - (ansible_facts['distribution'] == 'Debian' and ansible_facts['distribution_release'] == 'bullseye') or
             (ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_release'] == 'focal') or
             (ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_release'] == 'jammy') or
+            (ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_release'] == 'noble') or
             (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '8') or
             (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '9')
         msg: >


### PR DESCRIPTION
Keeps the requirements pins for the python versions used in Ubuntu 20/22 and add support for newer python versions in Ubuntu 24.