### PR TITLE
Switch repos from unmaintained/yoga to yoga-eol tag

### DIFF
--- a/playbooks/defaults/repo_packages/openstack_services.yml
+++ b/playbooks/defaults/repo_packages/openstack_services.yml
@@ -37,13 +37,13 @@ requirements_git_track_branch: unmaintained/yoga
 
 ## Adjutant service
 adjutant_git_repo: https://github.com/openstack/adjutant
-adjutant_git_install_branch: unmaintained/yoga
-adjutant_git_track_branch: unmaintained/yoga
+adjutant_git_install_branch: yoga-eol
+adjutant_git_track_branch: yoga-eol
 
 ## Adjutant dashboard plugin
 adjutant_dashboard_git_repo: https://github.com/openstack/adjutant-ui
-adjutant_dashboard_git_install_branch: unmaintained/yoga
-adjutant_dashboard_git_track_branch: unmaintained/yoga
+adjutant_dashboard_git_install_branch: yoga-eol
+adjutant_dashboard_git_track_branch: yoga-eol
 
 ## Aodh service
 aodh_git_repo: https://github.com/openstack/aodh
@@ -95,8 +95,8 @@ designate_git_track_branch: unmaintained/yoga
 
 ## Horizon Designate dashboard plugin
 designate_dashboard_git_repo: https://github.com/openstack/designate-dashboard
-designate_dashboard_git_install_branch: unmaintained/yoga
-designate_dashboard_git_track_branch: unmaintained/yoga
+designate_dashboard_git_install_branch: yoga-eol
+designate_dashboard_git_track_branch: yoga-eol
 
 
 ## Glance service
@@ -112,8 +112,8 @@ heat_git_track_branch: unmaintained/yoga
 
 ## Horizon Heat dashboard plugin
 heat_dashboard_git_repo: https://github.com/openstack/heat-dashboard
-heat_dashboard_git_install_branch: unmaintained/yoga
-heat_dashboard_git_track_branch: unmaintained/yoga
+heat_dashboard_git_install_branch: yoga-eol
+heat_dashboard_git_track_branch: yoga-eol
 
 ## Horizon service
 horizon_git_repo: https://github.com/openstack/horizon
@@ -273,8 +273,8 @@ trove_git_track_branch: unmaintained/yoga
 
 ## Horizon Trove dashboard plugin
 trove_dashboard_git_repo: https://github.com/openstack/trove-dashboard
-trove_dashboard_git_install_branch: unmaintained/yoga
-trove_dashboard_git_track_branch: unmaintained/yoga
+trove_dashboard_git_install_branch: yoga-eol
+trove_dashboard_git_track_branch: yoga-eol
 
 
 ## Octavia service
@@ -297,8 +297,8 @@ tacker_git_track_branch: unmaintained/yoga
 
 ## Horizon Octavia dashboard plugin
 octavia_dashboard_git_repo: https://github.com/openstack/octavia-dashboard
-octavia_dashboard_git_install_branch: unmaintained/yoga
-octavia_dashboard_git_track_branch: unmaintained/yoga
+octavia_dashboard_git_install_branch: yoga-eol
+octavia_dashboard_git_track_branch: yoga-eol
 
 
 ## Blazar service


### PR DESCRIPTION
adjutant, adjutant-ui, designate-dashboard, heat-dashboard, trove-dashboard and octavia-dashboard have dropped the branch; yoga-eol tag is the correct reference going forward.